### PR TITLE
feat!: add way of passing toolchain when invoking commands

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ jobs:
       with:
         node-version-file: '.nvmrc'
         cache: 'npm'
+    - uses: actions-rust-lang/setup-rust-toolchain@11df97af8e8102fd60b60a77dfbf58d40cd843b8 # v1.10.1
     - run: npm ci
     - run: npm run lint
     - run: npm run build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,8 @@ jobs:
         node-version-file: '.nvmrc'
         cache: 'npm'
     - uses: actions-rust-lang/setup-rust-toolchain@11df97af8e8102fd60b60a77dfbf58d40cd843b8 # v1.10.1
+      with:
+        toolchain: nightly,stable
     - run: npm ci
     - run: npm run lint
     - run: npm run build

--- a/__tests__/commands/cargoHack.test.ts
+++ b/__tests__/commands/cargoHack.test.ts
@@ -1,11 +1,14 @@
 import * as io from '@actions/io';
 
-import { CargoHack } from '../../src/commands/cargoHack';
+import { Cargo, CargoHack, CargoHackOptions } from '../../src/core';
 
 const SECONDS = 1000;
 
 describe('CargoHack', () => {
   const primaryKey = process.env.CI ? undefined : 'no-cache';
+  const options: CargoHackOptions = {
+    primaryKey,
+  };
 
   describe('install', () => {
     it(
@@ -18,7 +21,7 @@ describe('CargoHack', () => {
           console.log('cargo-hack already installed; skipping this test');
         } catch {
           // cargo-hack is not installed; install it
-          const cargoHack = await CargoHack.install('latest', primaryKey);
+          const cargoHack = await CargoHack.install(options);
           const exitCode = await cargoHack.call(['--version']);
           expect(exitCode).toBe(0);
         }
@@ -51,11 +54,34 @@ describe('CargoHack', () => {
     it(
       'installs cargo-hack if needed, otherwise reuses it',
       async () => {
-        const cargoHack = await CargoHack.getOrInstall(primaryKey);
+        const cargoHack = await CargoHack.getOrInstall(options);
         const exitCode = await cargoHack.call(['--version']);
         expect(exitCode).toBe(0);
       },
       90 * SECONDS,
     );
+
+    describe('with toolchain', () => {
+      it(
+        'uses cargo-hack with the given toolchain',
+        async () => {
+          // This test assumes that nightly Rust is installed.
+          const cargo = await Cargo.get('nightly');
+          if ((await cargo.call(['--version'])) === 0) {
+            const optionsWithToolchain: CargoHackOptions = {
+              ...options,
+              toolchain: 'nightly',
+            };
+            const cargoHack =
+              await CargoHack.getOrInstall(optionsWithToolchain);
+            const exitCode = await cargoHack.call(['--version']);
+            expect(exitCode).toBe(0);
+          } else {
+            console.log('Nightly Rust not installed; skipping this test');
+          }
+        },
+        90 * SECONDS,
+      );
+    });
   });
 });

--- a/__tests__/commands/cargoHack.test.ts
+++ b/__tests__/commands/cargoHack.test.ts
@@ -1,3 +1,4 @@
+import * as exec from '@actions/exec';
 import * as io from '@actions/io';
 
 import { Cargo, CargoHack, CargoHackOptions } from '../../src/core';
@@ -14,12 +15,9 @@ describe('CargoHack', () => {
     it(
       'installs cargo-hack',
       async () => {
-        try {
-          await io.which('cargo-hack', true);
-
-          // Simply skip this test
+        if (await io.which('cargo-hack')) {
           console.log('cargo-hack already installed; skipping this test');
-        } catch {
+        } else {
           // cargo-hack is not installed; install it
           const cargoHack = await CargoHack.install(options);
           const exitCode = await cargoHack.call(['--version']);
@@ -34,15 +32,12 @@ describe('CargoHack', () => {
     it(
       'fetches the installed cargo-hack',
       async () => {
-        try {
-          await io.which('cargo-hack', true);
-
+        if (await io.which('cargo-hack')) {
           // cargo-hack is installed, we can test it
           const cargoHack = await CargoHack.get();
           const exitCode = await cargoHack.call(['--version']);
           expect(exitCode).toBe(0);
-        } catch {
-          // Simply skip this test
+        } else {
           console.log('cargo-hack not installed; skipping this test');
         }
       },
@@ -67,7 +62,11 @@ describe('CargoHack', () => {
         async () => {
           // This test assumes that nightly Rust is installed.
           const cargo = await Cargo.get('nightly');
-          if ((await cargo.call(['--version'])) === 0) {
+          const execOptions: exec.ExecOptions = {
+            ignoreReturnCode: true,
+            failOnStdErr: false,
+          };
+          if ((await cargo.call(['--version'], execOptions)) === 0) {
             const optionsWithToolchain: CargoHackOptions = {
               ...options,
               toolchain: 'nightly',

--- a/__tests__/commands/cross.test.ts
+++ b/__tests__/commands/cross.test.ts
@@ -1,0 +1,83 @@
+import * as io from '@actions/io';
+
+import { Cargo, Cross, CrossOptions } from '../../src/core';
+
+const SECONDS = 1000;
+
+describe('Cross', () => {
+  const primaryKey = process.env.CI ? undefined : 'no-cache';
+  const options: CrossOptions = {
+    primaryKey,
+  };
+
+  describe('install', () => {
+    it(
+      'installs cross',
+      async () => {
+        try {
+          await io.which('cross', true);
+          console.log('cross already installed; skipping this test');
+        } catch {
+          // cross is not installed; install it
+          const cross = await Cross.install(options);
+          const exitCode = await cross.call(['--version']);
+          expect(exitCode).toBe(0);
+        }
+      },
+      90 * SECONDS,
+    );
+  });
+
+  describe('get', () => {
+    it(
+      'fetches the installed cross',
+      async () => {
+        try {
+          await io.which('cross', true);
+
+          // cross is installed, we can test it
+          const cross = await Cross.get();
+          const exitCode = await cross.call(['--version']);
+          expect(exitCode).toBe(0);
+        } catch {
+          console.log('cross not installed; skipping this test');
+        }
+      },
+      90 * SECONDS,
+    );
+  });
+
+  describe('getOrInstall', () => {
+    it(
+      'installs cross if needed, otherwise reuses it',
+      async () => {
+        const cross = await Cross.getOrInstall(options);
+        const exitCode = await cross.call(['--version']);
+        expect(exitCode).toBe(0);
+      },
+      90 * SECONDS,
+    );
+
+    describe('with toolchain', () => {
+      it(
+        'uses cross with the given toolchain',
+        async () => {
+          // This test assumes that nightly Rust is installed.
+          const cargo = await Cargo.get('nightly');
+          if ((await cargo.call(['--version'])) === 0) {
+            const optionsWithToolchain: CrossOptions = {
+              ...options,
+              toolchain: 'nightly',
+            };
+            const cross = await Cross.getOrInstall(optionsWithToolchain);
+            const exitCode = await cross.call(['--version']);
+            expect(exitCode).toBe(0);
+          } else {
+            console.log('Nightly Rust not installed; skipping this test');
+          }
+        },
+        90 * SECONDS,
+      );
+    });
+  });
+});

--- a/__tests__/commands/cross.test.ts
+++ b/__tests__/commands/cross.test.ts
@@ -1,6 +1,7 @@
 import * as io from '@actions/io';
 
 import { Cargo, Cross, CrossOptions } from '../../src/core';
+import * as exec from '@actions/exec';
 
 const SECONDS = 1000;
 
@@ -14,10 +15,9 @@ describe('Cross', () => {
     it(
       'installs cross',
       async () => {
-        try {
-          await io.which('cross', true);
+        if (await io.which('cross')) {
           console.log('cross already installed; skipping this test');
-        } catch {
+        } else {
           // cross is not installed; install it
           const cross = await Cross.install(options);
           const exitCode = await cross.call(['--version']);
@@ -32,14 +32,12 @@ describe('Cross', () => {
     it(
       'fetches the installed cross',
       async () => {
-        try {
-          await io.which('cross', true);
-
+        if (await io.which('cross')) {
           // cross is installed, we can test it
           const cross = await Cross.get();
           const exitCode = await cross.call(['--version']);
           expect(exitCode).toBe(0);
-        } catch {
+        } else {
           console.log('cross not installed; skipping this test');
         }
       },
@@ -64,7 +62,11 @@ describe('Cross', () => {
         async () => {
           // This test assumes that nightly Rust is installed.
           const cargo = await Cargo.get('nightly');
-          if ((await cargo.call(['--version'])) === 0) {
+          const execOptions: exec.ExecOptions = {
+            ignoreReturnCode: true,
+            failOnStdErr: false,
+          };
+          if ((await cargo.call(['--version'], execOptions)) === 0) {
             const optionsWithToolchain: CrossOptions = {
               ...options,
               toolchain: 'nightly',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@clechasseur/rs-actions-core",
-  "version": "4.0.2",
+  "version": "5.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@clechasseur/rs-actions-core",
-      "version": "4.0.2",
+      "version": "5.0.0",
       "license": "MIT",
       "dependencies": {
         "@actions/cache": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": false,
   "name": "@clechasseur/rs-actions-core",
-  "version": "4.0.2",
+  "version": "5.0.0",
   "author": "clechasseur",
   "license": "MIT",
   "description": "Core functionality for the rs-* actions repos",

--- a/src/commands/cargoHack.ts
+++ b/src/commands/cargoHack.ts
@@ -3,70 +3,107 @@ import * as io from '@actions/io';
 import * as core from '@actions/core';
 import * as exec from '@actions/exec';
 
-import { Cargo } from './cargo';
+import { Cargo, cargoToolchainArg } from './cargo';
+
+/**
+ * Possible arguments to {@link CargoHack.getOrInstall} and
+ * {@link CargoHack.install}.
+ */
+export interface CargoHackOptions {
+  /**
+   * Toolchain to use when calling `cargo-hack`.
+   *
+   * If `undefined`, the default toolchain will be used.
+   *
+   * Note that this toolchain is not used to _install_ `cargo-hack` itself,
+   * only to call it once subsequently installed.
+   */
+  toolchain?: string;
+
+  /**
+   * Version of `cargo-hack` to install.
+   *
+   * If `undefined` or set to `'latest'`, the latest version will be installed.
+   */
+  version?: string;
+
+  /**
+   * Primary cache key to use when caching the installed `cargo-hack`.
+   *
+   * If `undefined`, a default value will be used.
+   * If set to `'no-cache'`, caching will be disabled.
+   */
+  primaryKey?: string;
+
+  /**
+   * Optional additional restore keys to use when looking for an installed
+   * version of `cargo-hack`.
+   */
+  restoreKeys?: string[];
+}
 
 export class CargoHack {
-  private readonly path: string;
+  private readonly toolchain: string;
 
-  private constructor(path: string) {
-    this.path = path;
+  private constructor(toolchain?: string) {
+    this.toolchain = cargoToolchainArg(toolchain);
   }
 
   /**
-   * Gets the installed version of `cargo-hack`, or installs
-   * the latest version if not yet installed.
+   * Gets the installed version of `cargo-hack`, or installs it if not yet installed.
+   *
+   * @param options Options for getting or installing `cargo-hack`. See
+   *                {@link CargoHackOptions}.
    */
   public static async getOrInstall(
-    primaryKey?: string,
-    restoreKeys?: string[],
+    options?: CargoHackOptions,
   ): Promise<CargoHack> {
     try {
-      return await CargoHack.get();
+      return await CargoHack.get(options?.toolchain);
     } catch (error) {
       core.debug((error as Error).message);
-      return await CargoHack.install('latest', primaryKey, restoreKeys);
+      return await CargoHack.install(options);
     }
   }
 
   /**
    * Gets the installed version of `cargo-hack`.
    * Throws an exception if not installed.
+   *
+   * @param toolchain Optional toolchain to use when invoking `cargo-hack`.
    */
-  public static async get(): Promise<CargoHack> {
-    const path = await io.which('cargo-hack', true);
+  public static async get(toolchain?: string): Promise<CargoHack> {
+    // io.which will throw an exception if not installed, but we don't need the path proper.
+    await io.which('cargo-hack', true);
 
-    return new CargoHack(path);
+    return new CargoHack(toolchain);
   }
 
   /**
-   * Install the given version of `cargo-hack` (or the latest
-   * version if `version` is `undefined` or `latest`).
+   * Install `cargo-hack` and caches it for future use.
    *
-   * Caching can be disabled by passing `no-cache` as primary key.
+   * @param options Options to use to install `cargo-hack`. See
+   *                {@link CargoHackOptions}
    */
-  public static async install(
-    version?: string,
-    primaryKey?: string,
-    restoreKeys?: string[],
-  ): Promise<CargoHack> {
+  public static async install(options?: CargoHackOptions): Promise<CargoHack> {
     const cargo = await Cargo.get();
 
     // Compiling cargo-hack might require a version of Rust that the
     // one currently installed and configured, so move to the
-    // temp directory (so as to get the system version of Rust).
+    // temp directory (to get the system version of Rust).
 
     const cwd = process.cwd();
     process.chdir(os.tmpdir());
 
     try {
-      const cargoHackPath = await cargo.install(
+      await cargo.install(
         'cargo-hack',
-        version,
-        primaryKey,
-        restoreKeys,
+        options?.version,
+        options?.primaryKey,
+        options?.restoreKeys,
       );
 
-      return new CargoHack(cargoHackPath);
+      return new CargoHack(options?.toolchain);
     } finally {
       // It is important to chdir back!
       process.chdir(cwd);
@@ -76,13 +113,17 @@ export class CargoHack {
 
   /**
    * Runs `cargo hack ${args}`.
+   *
+   * @param args Arguments to pass to `cargo-hack` (after `cargo hack ...`).
+   * @param options Optional exec options.
+   * @returns `cargo-hack` exit code.
    */
   public async call(
     args: string[],
     options?: exec.ExecOptions,
   ): Promise<number> {
-    // We invoke `cargo-hack`, but the executable expects to
-    // be called like `cargo`, so we must call `cargo-hack hack ...`
-    return await exec.exec(this.path, ['hack', ...args], options);
+    // cargo-hack is a cargo subcommand so we must actually call it through cargo.
+    const cargo = await Cargo.get(this.toolchain);
+    return await cargo.call(['hack', ...args], options);
   }
 }

--- a/src/commands/cross.ts
+++ b/src/commands/cross.ts
@@ -3,57 +3,91 @@ import * as io from '@actions/io';
 import * as core from '@actions/core';
 import * as exec from '@actions/exec';
 
-import { Cargo } from './cargo';
+import { Cargo, cargoToolchainArg } from './cargo';
+
+/**
+ * Possible arguments to {@link Cross.getOrInstall} and
+ * {@link Cross.install}.
+ */
+export interface CrossOptions {
+  /**
+   * Toolchain to use when calling `cross`.
+   *
+   * If `undefined`, the default toolchain will be used.
+   *
+   * Note that this toolchain is not used to _install_ `cross` itself,
+   * only to call it once subsequently installed.
+   */
+  toolchain?: string;
+
+  /**
+   * Version of `cross` to install.
+   *
+   * If `undefined` or set to `'latest'`, the latest version will be installed.
+   */
+  version?: string;
+
+  /**
+   * Primary cache key to use when caching the installed `cross`.
+   *
+   * If `undefined`, a default value will be used.
+   * If set to `'no-cache'`, caching will be disabled.
+   */
+  primaryKey?: string;
+
+  /**
+   * Optional additional restore keys to use when looking for an installed
+   * version of `cross`.
+   */
+  restoreKeys?: string[];
+}
 
 export class Cross {
   private readonly path: string;
+  private readonly toolchain: string;
 
-  private constructor(path: string) {
+  private constructor(path: string, toolchain?: string) {
     this.path = path;
+    this.toolchain = cargoToolchainArg(toolchain);
   }
 
   /**
-   * Gets the installed version of `cross`, or installs
-   * it if not yet installed.
+   * Gets the installed version of `cross`, or installs it if not yet installed.
+   *
+   * @param options Options for getting or installing `cross`. See {@link CrossOptions}.
    */
-  public static async getOrInstall(
-    primaryKey?: string,
-    restoreKeys?: string[],
-  ): Promise<Cross> {
+  public static async getOrInstall(options?: CrossOptions): Promise<Cross> {
     try {
-      return await Cross.get();
+      return await Cross.get(options?.toolchain);
     } catch (error) {
       core.debug((error as Error).message);
-      return await Cross.install('latest', primaryKey, restoreKeys);
+      return await Cross.install(options);
     }
   }
 
   /**
    * Gets the installed version of `cross`.
    * Throws an exception if not installed.
+   *
+   * @param toolchain Optional toolchain to use when invoking `cross`.
    */
-  public static async get(): Promise<Cross> {
+  public static async get(toolchain?: string): Promise<Cross> {
     const path = await io.which('cross', true);
 
-    return new Cross(path);
+    return new Cross(path, toolchain);
   }
 
   /**
-   * Install the given version of `cross` (or the latest
-   * version if `version` is `undefined` or `latest`).
+   * Install `cross` and caches it for future use.
    *
-   * Caching can be disabled by passing `no-cache` as primary key.
+   * @param options Options for getting or installing `cross`. See {@link CrossOptions}.
    */
-  public static async install(
-    version?: string,
-    primaryKey?: string,
-    restoreKeys?: string[],
-  ): Promise<Cross> {
+  public static async install(options?: CrossOptions): Promise<Cross> {
     const cargo = await Cargo.get();
 
     // Compiling cross might require a version of Rust that the
     // one currently installed and configured, so move to the
-    // temp directory (so as to get the system version of Rust).
+    // temp directory (to get the system version of Rust).
 
     const cwd = process.cwd();
     process.chdir(os.tmpdir());
@@ -61,12 +95,12 @@ export class Cross {
     try {
       const crossPath = await cargo.install(
         'cross',
-        version,
-        primaryKey,
-        restoreKeys,
+        options?.version,
+        options?.primaryKey,
+        options?.restoreKeys,
       );
 
-      return new Cross(crossPath);
+      return new Cross(crossPath, options?.toolchain);
     } finally {
       // It is important to chdir back!
       process.chdir(cwd);
@@ -81,6 +115,10 @@ export class Cross {
     args: string[],
     options?: exec.ExecOptions,
   ): Promise<number> {
-    return await exec.exec(this.path, args, options);
+    return await exec.exec(this.path, this.callArgs(args), options);
+  }
+
+  private callArgs(args: string[]): string[] {
+    return this.toolchain ? [this.toolchain, ...args] : args;
   }
 }


### PR DESCRIPTION
This used to be done in the actions themselves, but it doesn't work properly for things like `cargo-hack`
